### PR TITLE
added critical log when both connection is lost

### DIFF
--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -496,7 +496,6 @@ func disconnectDevicePath(devicePath string) error {
 		return true
 	})
 
-	mu.Lock()
 	for _, p := range paths {
 		klog.Infof("Disconnecting device %s", p.Name)
 		disconnectCmd := []string{"nvme", "disconnect", "-d", p.Name}
@@ -505,6 +504,8 @@ func disconnectDevicePath(devicePath string) error {
 			klog.Errorf("Failed to disconnect device %s: %v", p.Name, err)
 		}
 	}
+
+	mu.Lock()
 	klog.Infof("deviceSubsystemMap before delete: %+v", deviceSubsystemMap)
 	delete(deviceSubsystemMap, realPath)
 	klog.Infof("deviceSubsystemMap after Delete: %+v", deviceSubsystemMap)
@@ -793,12 +794,12 @@ func disconnectViaNVMe(devicePath string, path path) error {
 		"nvme", "disconnect", "-d", path.Name,
 	}
 
-	mu.Lock()
 	if err := execWithTimeoutRetry(cmd, 40, 1); err != nil {
 		klog.Errorf("nvme disconnect failed: %v", err)
 		return err
 	}
 
+	mu.Lock()
 	delete(deviceSubsystemMap, devicePath)
 	mu.Unlock()
 

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -506,9 +506,7 @@ func disconnectDevicePath(devicePath string) error {
 	}
 
 	mu.Lock()
-	klog.Infof("deviceSubsystemMap before delete: %+v", deviceSubsystemMap)
 	delete(deviceSubsystemMap, realPath)
-	klog.Infof("deviceSubsystemMap after Delete: %+v", deviceSubsystemMap)
 	mu.Unlock()
 
 	return nil
@@ -647,7 +645,6 @@ func reconnectSubsystems() error {
 	for devPath := range deviceSubsystemMap {
 		if !currentDevices[devPath] {
 			klog.Errorf("Device %s is no longer present — all NVMe-oF connections were lost and the kernel removed the device", devPath)
-			klog.Infof("deviceSubsystemMap during device check: %+v", deviceSubsystemMap)
 			delete(deviceSubsystemMap, devPath)
 		}
 	}

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -505,8 +505,9 @@ func disconnectDevicePath(devicePath string) error {
 			klog.Errorf("Failed to disconnect device %s: %v", p.Name, err)
 		}
 	}
-
+	klog.Infof("deviceSubsystemMap before delete: %+v", deviceSubsystemMap)
 	delete(deviceSubsystemMap, devicePath)
+	klog.Infof("deviceSubsystemMap after Delete: %+v", deviceSubsystemMap)
 	mu.Unlock()
 
 	return nil
@@ -611,8 +612,8 @@ func reconnectSubsystems() error {
 			continue
 		}
 
-		deviceSubsystemMap[device.devicePath] = true
 		currentDevices[device.devicePath] = true
+		deviceSubsystemMap[device.devicePath] = true
 
 		for _, host := range subsystems {
 			for _, subsystem := range host.Subsystems {
@@ -645,6 +646,7 @@ func reconnectSubsystems() error {
 	for devPath := range deviceSubsystemMap {
 		if !currentDevices[devPath] {
 			klog.Errorf("Device %s is no longer present — all NVMe-oF connections were lost and the kernel removed the device", devPath)
+			klog.Infof("deviceSubsystemMap during device check: %+v", deviceSubsystemMap)
 			delete(deviceSubsystemMap, devPath)
 		}
 	}

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -506,7 +506,7 @@ func disconnectDevicePath(devicePath string) error {
 		}
 	}
 	klog.Infof("deviceSubsystemMap before delete: %+v", deviceSubsystemMap)
-	delete(deviceSubsystemMap, devicePath)
+	delete(deviceSubsystemMap, realPath)
 	klog.Infof("deviceSubsystemMap after Delete: %+v", deviceSubsystemMap)
 	mu.Unlock()
 

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -496,7 +496,7 @@ func disconnectDevicePath(devicePath string) error {
 		return true
 	})
 
-	mapMu.Lock()
+	mu.Lock()
 	for _, p := range paths {
 		klog.Infof("Disconnecting device %s", p.Name)
 		disconnectCmd := []string{"nvme", "disconnect", "-d", p.Name}
@@ -507,7 +507,7 @@ func disconnectDevicePath(devicePath string) error {
 	}
 
 	delete(deviceSubsystemMap, devicePath)
-	mapMu.Unlock()
+	mu.Unlock()
 
 	return nil
 }

--- a/pkg/util/initiator.go
+++ b/pkg/util/initiator.go
@@ -114,7 +114,7 @@ type nvmeDeviceInfo struct {
 
 var (
 	deviceSubsystemMap = make(map[string]bool)
-	mapMu              sync.RWMutex
+	mu                 sync.Mutex
 )
 
 // clusterConfig represents the Kubernetes secret structure


### PR DESCRIPTION
csi-node log output 
```
I0821 10:28:00.828997       1 nodeserver.go:446] mount /var/lib/kubelet/plugins/kubernetes.io/csi/csi.simplyblock.io/c3964f7661a24283c3ccce6d8c2f8560df4d854cbac73f5785fbd97806f11f7a/globalmount/9c65aff6-f1b9-4ed7-92ed-79740097477d:testing1:a9c50551-3082-4198-8aac-e2d9c3132594 to /var/lib/kubelet/pods/adbf9c2e-0483-45db-871f-c502c52688b9/volumes/kubernetes.io~csi/pvc-3e8a235e-f856-4d6a-85a5-e6b0b1c8f820/mount, fstype: ext4, flags: [bind]
I0821 10:28:00.832483       1 utils.go:79] GRPC response: {}
I0821 10:28:52.059302       1 utils.go:73] GRPC call: /csi.v1.Node/NodeGetCapabilities
I0821 10:28:52.059333       1 utils.go:74] GRPC request: {}
I0821 10:28:52.059399       1 utils.go:79] GRPC response: {"capabilities":[{"Type":{"Rpc":{"type":1}}},{"Type":{"Rpc":{"type":3}}},{"Type":{"Rpc":{"type":4}}}]}
I0821 10:29:59.968255       1 utils.go:73] GRPC call: /csi.v1.Node/NodeGetCapabilities
I0821 10:29:59.968286       1 utils.go:74] GRPC request: {}
I0821 10:29:59.968356       1 utils.go:79] GRPC response: {"capabilities":[{"Type":{"Rpc":{"type":1}}},{"Type":{"Rpc":{"type":3}}},{"Type":{"Rpc":{"type":4}}}]}
E0821 10:30:33.029234       1 initiator.go:639] Device /dev/nvme0n1 is no longer present — all NVMe-oF connections were lost and the kernel removed the device
I0821 10:31:19.094152       1 utils.go:73] GRPC call: /csi.v1.Node/NodeGetCapabilities
I0821 10:31:19.094185       1 utils.go:74] GRPC request: {}
I0821 10:31:19.094353       1 utils.go:79] GRPC response: {"capabilities":[{"Type":{"Rpc":{"type":1}}},{"Type":{"Rpc":{"type":3}}},{"Type":{"Rpc":{"type":4}}}]}
```